### PR TITLE
Fix the wrong direction of a message, when a bot sends response to user

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func handleMsgFromSlack(event *slack.MessageEvent) {
 	channelID, timestamp, err := slackClient.PostMessage(
 		user.ID,
 		slack.MsgOptionText("hey", false),
+		slack.MsgOptionAttachments(attachment),
 		slack.MsgOptionAsUser(true),
 	)
 

--- a/main.go
+++ b/main.go
@@ -39,15 +39,15 @@ func main() {
 func handleMsgFromSlack(event *slack.MessageEvent) {
 	user, err := slackClient.GetUserInfo(event.User)
 
-	timestamp, err := slackClient.PostEphemeral(
-		event.Channel,
+	channelID, timestamp, err := slackClient.PostMessage(
 		user.ID,
 		slack.MsgOptionText("hey", false),
+		slack.MsgOptionAsUser(true),
 	)
 
 	if err != nil {
 		fmt.Printf("Ooops! There is an error: %s\n", err)
 		return
 	}
-	fmt.Printf("Message successfully sent to channel at %s", timestamp)
+	fmt.Printf("Message successfully sent to channel %s at %s", channelID, timestamp)
 }

--- a/main.go
+++ b/main.go
@@ -38,6 +38,17 @@ func main() {
 
 func handleMsgFromSlack(event *slack.MessageEvent) {
 	user, err := slackClient.GetUserInfo(event.User)
+	attachment := slack.Attachment{
+		Pretext: "Hello @" + user.Name + "",
+		Text:    "I am happy to see you here!",
+
+		Fields: []slack.AttachmentField{
+			slack.AttachmentField{
+				Title: "Title of the attachment",
+				Value: "This is the body",
+			},
+		},
+	}
 
 	channelID, timestamp, err := slackClient.PostMessage(
 		user.ID,


### PR DESCRIPTION
 ## What does it do?
- [x] It fixes the wrong direction of a message when a bot sends a response to user
- [x] It implements the answers gotten from this issue [#785](https://github.com/slack-go/slack/issues/785)

## Tasks to be completed in this PR
- [x] Fix the wrong directing of `PostMessage`

